### PR TITLE
Feature guildbasedactivitynoticeconfig

### DIFF
--- a/kuBot.njsproj
+++ b/kuBot.njsproj
@@ -11,7 +11,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>6db0e2f6-df00-474e-93ff-b9391ff233cd</ProjectGuid>
     <ProjectHome>.</ProjectHome>
-    <StartupFile>deploy\bot.js</StartupFile>
+    <StartupFile>
+    </StartupFile>
     <StartWebBrowser>False</StartWebBrowser>
     <SearchPath>
     </SearchPath>

--- a/sources/businesslogic/services/guild.config.service.ts
+++ b/sources/businesslogic/services/guild.config.service.ts
@@ -25,7 +25,8 @@ export abstract class GuildConfigService {
             return {
                 id: guild.id,
                 defaultChannel: guild.channels.find(channel => channel.name === guildSettings.mainChannel),
-                emergencyChannel: guild.channels.find(channel => channel.name === guildSettings.emergencyChannel)
+                emergencyChannel: guild.channels.find(channel => channel.name === guildSettings.emergencyChannel),
+                minimumPlayersCount: guildSettings.activityNoticeMinPlayers
             };
         } else {
             return Promise.reject(new Error(`Couldn't find settings for guild ${guild.id}`));

--- a/sources/front/tasks/cyclic.activity.notice.task.ts
+++ b/sources/front/tasks/cyclic.activity.notice.task.ts
@@ -110,14 +110,24 @@ export abstract class CyclicActivityNotice {
             }
         });
 
-        let guildWatchedPlayers = this.watchedPlayers.filter(player => player.guildId === guildId);
+        let guildWatchedPlayers = this.watchedPlayers.filter(player => player.guildId === guildId).map(player => player.name);
+        let onlineWatchedPlayers = this.onlinePlayers.filter(player =>
+            systems.some(el => el === player.System) &&
+            guildWatchedPlayers.some(watchedPlayer => watchedPlayer === player.Name)
+        );
 
-        activity.push({
-            name: 'Individuals of interest',
-            playersCount: guildWatchedPlayers.length
-        });
+        if (onlineWatchedPlayers.length > 0) {
+            activity.push({
+                name: 'Individuals of interest',
+                playersCount: onlineWatchedPlayers.length
+            });
+        }
 
         return activity;
+    }
+
+    private static FetchPlayersActivity(): void {
+
     }
 
     private static async CompareActivity(

--- a/sources/types/businesslogic/business.types.ts
+++ b/sources/types/businesslogic/business.types.ts
@@ -2,9 +2,10 @@
 import { WatchedPlayer } from './../dbase/persisted.types';
 
 export interface MappedGuildConfiguration {
-    id: string,
-    defaultChannel: GuildChannel,
-    emergencyChannel: GuildChannel
+    id: string;
+    defaultChannel: GuildChannel;
+    emergencyChannel: GuildChannel;
+    minimumPlayersCount: number;
 }
 
 export interface ScannedFaction {

--- a/sources/types/dbase/persisted.types.ts
+++ b/sources/types/dbase/persisted.types.ts
@@ -25,6 +25,7 @@ export interface GuildConfiguration {
     adminChannel: string;
     emergencyChannel: string;
     acknowledged: string;
+    activityNoticeMinPlayers: number;
 }
 
 /* ---------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Improving activity notice feature a little bit:
- Include condition is no longer depending on the player count for each faction. There is now a global minimum players count setting for each guild. A report will be sent if there is more players found in the area than the minimum count specified in the guild settings.
- Added watched players to the activity notice as well.