### PR TITLE
Fix guildconfigtextchannels

### DIFF
--- a/kuBot.njsproj
+++ b/kuBot.njsproj
@@ -124,6 +124,9 @@
     <TypeScriptCompile Include="sources\front\commands\watch.command.ts">
       <SubType>Code</SubType>
     </TypeScriptCompile>
+    <TypeScriptCompile Include="sources\front\events\discord.error.event.ts">
+      <SubType>Code</SubType>
+    </TypeScriptCompile>
     <TypeScriptCompile Include="sources\front\events\discord.guild.create.event.ts">
       <SubType>Code</SubType>
     </TypeScriptCompile>

--- a/sources/bot.ts
+++ b/sources/bot.ts
@@ -4,6 +4,7 @@ import { ClientReadyEvent } from './front/events/discord.client.ready.event';
 import { GuildCreateEvent } from './front/events/discord.guild.create.event';
 import { GuildDeleteEvent } from './front/events/discord.guild.delete.event';
 import { MessageEvent } from './front/events/discord.message.event';
+import { ErrorEvent } from './front/events/discord.error.event';
 
 import { PrivateSettings } from './configuration/pivate.settings.mapping';
 
@@ -24,5 +25,8 @@ client.on('guildDelete', async (guild) => {
 });
 client.on('message', async (message) => {
     await MessageEvent.React(message, client.user.username, client.user.avatarURL);
+});
+client.on('error', async (error) => {
+    await ErrorEvent.React(error);
 });
 client.login(process.env['apiKey']);

--- a/sources/businesslogic/services/guild.configuration.service.ts
+++ b/sources/businesslogic/services/guild.configuration.service.ts
@@ -4,14 +4,13 @@ import { promisify } from 'util';
 import { FactionWatchStore } from './../../dal/mongodb/stores/watchlists/faction.watch.store';
 import { RegionWatchStore } from './../../dal/mongodb/stores/watchlists/region.watch.store';
 import { GuildsStore } from './../../dal/mongodb/stores/business/guilds.store';
-import { MappedGuildConfiguration } from './../../types/businesslogic/business.types';
 import { GuildConfiguration } from './../../types/dbase/persisted.types';
 
 import { GuildConfigurationValidator } from './../data/guild.config.validator';
 
 export abstract class GuildConfigurationService {
 
-    public static guildsSettings: MappedGuildConfiguration[] = [];
+    public static guildsSettings: GuildConfiguration[] = [];
 
     public static async Initialize(
         client: Client
@@ -34,10 +33,7 @@ export abstract class GuildConfigurationService {
                 messagesImage: persistedGuildParams.messagesImage,
                 messagesFooterName: persistedGuildParams.messagesFooterName,
                 acknowledged: persistedGuildParams.acknowledged,
-                activityNoticeMinPlayers: persistedGuildParams.activityNoticeMinPlayers,
-
-                defaultChannel: guild.channels.find(channel => channel.name === persistedGuildParams.mainChannelName),
-                emergencyChannel: guild.channels.find(channel => channel.name === persistedGuildParams.emergencyChannelName),
+                activityNoticeMinPlayers: persistedGuildParams.activityNoticeMinPlayers
 
             });
         });
@@ -59,8 +55,8 @@ export abstract class GuildConfigurationService {
             throw error;
         }
 
-        let defaultChannel = this.GetChannel(parsed.guildSettings.mainChannelName, channels);
-        let emergencyChannel = this.GetChannel(parsed.guildSettings.emergencyChannelName, channels);
+        this.CheckChannel(parsed.guildSettings.mainChannelName, channels);
+        this.CheckChannel(parsed.guildSettings.emergencyChannelName, channels);
 
         await FactionWatchStore.set(guildId, parsed.factions.map(faction => ({
             guildId: guildId,
@@ -90,19 +86,16 @@ export abstract class GuildConfigurationService {
             messagesImage: parsed.guildSettings.messagesImage,
             messagesFooterName: parsed.guildSettings.messagesFooterName,
             acknowledged: parsed.guildSettings.acknowledged,
-            activityNoticeMinPlayers: parsed.guildSettings.activityNoticeMinPlayers,
-
-            defaultChannel: defaultChannel,
-            emergencyChannel: emergencyChannel
+            activityNoticeMinPlayers: parsed.guildSettings.activityNoticeMinPlayers
         };
 
         return true;
     }
 
-    private static GetChannel(
+    private static CheckChannel(
         name: string,
         channels: GuildChannel[]
-    ): GuildChannel {
+    ): void {
 
         let channel = channels.find(channel => channel.name === name);
 
@@ -116,7 +109,5 @@ export abstract class GuildConfigurationService {
             error.name = 'Custom';
             throw error;
         }
-
-        return <GuildChannel>channel;
     }       
 }

--- a/sources/front/events/discord.client.ready.event.ts
+++ b/sources/front/events/discord.client.ready.event.ts
@@ -15,7 +15,7 @@ export abstract class ClientReadyEvent {
 
             await GuildConfigurationService.Initialize(client);
 
-            await CyclicActivityNotice.Start();
+            await CyclicActivityNotice.Start(client);
 
             // let link = generateInviteLink(client);
 

--- a/sources/front/events/discord.error.event.ts
+++ b/sources/front/events/discord.error.event.ts
@@ -1,0 +1,13 @@
+﻿import { Client } from 'discord.js';
+
+import { ErrorsLogging } from './../../businesslogic/util/errors.logging.helper';
+
+export abstract class ErrorEvent {
+
+    public static async React(
+        error: Error
+    ): Promise<void> {
+        console.log('Error: ', error);
+        await ErrorsLogging.Save(error);
+    }
+}

--- a/sources/front/events/discord.guild.create.event.ts
+++ b/sources/front/events/discord.guild.create.event.ts
@@ -45,10 +45,7 @@ export abstract class GuildCreateEvent {
                     messagesImage: defaultSettings.messagesImage,
                     messagesFooterName: defaultSettings.messagesFooterName,
                     acknowledged: defaultSettings.acknowledged,
-                    activityNoticeMinPlayers: defaultSettings.activityNoticeMinPlayers,
-
-                    defaultChannel: guild.channels.find(channel => channel.name === defaultSettings.mainChannelName),
-                    emergencyChannel: guild.channels.find(channel => channel.name === defaultSettings.emergencyChannelName),
+                    activityNoticeMinPlayers: defaultSettings.activityNoticeMinPlayers
                 });
             }
             else {

--- a/sources/types/businesslogic/business.types.ts
+++ b/sources/types/businesslogic/business.types.ts
@@ -1,10 +1,5 @@
 ﻿import { GuildChannel } from 'discord.js';
-import { WatchedPlayer, GuildConfiguration } from './../dbase/persisted.types';
-
-export interface MappedGuildConfiguration extends GuildConfiguration {
-    defaultChannel: GuildChannel;
-    emergencyChannel: GuildChannel;
-}
+import { WatchedPlayer } from './../dbase/persisted.types';
 
 export interface ScannedFaction {
     name: string;


### PR DESCRIPTION
Fixing guilds configuration logic; initializing channels as application start was causing issues if targeted channels were to be deleted.
Emergency channel location is now done directly in the cyclic emergency notice task; if no channel can be found, task ends for that guild.