### PR TITLE
Fixing global errors logging

### DIFF
--- a/sources/bot.ts
+++ b/sources/bot.ts
@@ -4,7 +4,7 @@ import { ClientReadyEvent } from './front/events/discord.client.ready.event';
 import { GuildCreateEvent } from './front/events/discord.guild.create.event';
 import { GuildDeleteEvent } from './front/events/discord.guild.delete.event';
 import { MessageEvent } from './front/events/discord.message.event';
-import { ErrorEvent } from './front/events/discord.error.event';
+import { GlobalErrorEvent } from './front/events/discord.error.event';
 
 import { PrivateSettings } from './configuration/pivate.settings.mapping';
 
@@ -27,6 +27,6 @@ client.on('message', async (message) => {
     await MessageEvent.React(message, client.user.username, client.user.avatarURL);
 });
 client.on('error', async (error) => {
-    await ErrorEvent.React(error);
+    await GlobalErrorEvent.React(error);
 });
 client.login(process.env['apiKey']);

--- a/sources/businesslogic/util/errors.logging.helper.ts
+++ b/sources/businesslogic/util/errors.logging.helper.ts
@@ -10,4 +10,12 @@ export abstract class ErrorsLogging {
         let desc = `\r\n-----------------------------\r\n${moment().format('MM/DD/YYYY HH:mm:ss')}\r\n${error.stack}`;
         await FilesHelper.Append('./err.log', desc);
     }
+
+    public static async SaveGlobal(
+        error: Error
+    ): Promise<void> {
+        let errorData = (error.stack !== undefined) ? error.stack : error.message;
+        let desc = `\r\n-----------------------------\r\n${moment().format('MM/DD/YYYY HH:mm:ss')}\r\n${errorData}`;
+        await FilesHelper.Append('./err.log', desc);
+    }
 }

--- a/sources/front/events/discord.error.event.ts
+++ b/sources/front/events/discord.error.event.ts
@@ -2,12 +2,11 @@
 
 import { ErrorsLogging } from './../../businesslogic/util/errors.logging.helper';
 
-export abstract class ErrorEvent {
+export abstract class GlobalErrorEvent {
 
     public static async React(
         error: Error
     ): Promise<void> {
-        console.log('Error: ', error);
-        await ErrorsLogging.Save(error);
+        await ErrorsLogging.SaveGlobal(error);
     }
 }


### PR DESCRIPTION
There was no stack-trace for "read ECONNRESET" websocket errors, which made logger append an undefined in errors logging file.