### PR TITLE
Fix activitynotice uniquetasking

### DIFF
--- a/kubot.njsproj
+++ b/kubot.njsproj
@@ -11,8 +11,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>6db0e2f6-df00-474e-93ff-b9391ff233cd</ProjectGuid>
     <ProjectHome>.</ProjectHome>
-    <StartupFile>
-    </StartupFile>
+    <StartupFile>dist\bot.js</StartupFile>
     <StartWebBrowser>False</StartWebBrowser>
     <SearchPath>
     </SearchPath>

--- a/sources/bot.ts
+++ b/sources/bot.ts
@@ -15,7 +15,6 @@ const client = new Discord.Client({
 });
 
 client.on('ready', async () => {
-    console.log(`entered ready (${client.uptime})`);
     await ClientReadyEvent.React(client);
 });
 client.on('guildCreate', async (guild) => {
@@ -28,7 +27,6 @@ client.on('message', async (message) => {
     await MessageEvent.React(message, client.user.username, client.user.avatarURL);
 });
 client.on('error', async (error) => {
-    console.log(`entered error (${client.uptime})`);
     await GlobalErrorEvent.React(error);
 });
 client.login(process.env['apiKey']);

--- a/sources/bot.ts
+++ b/sources/bot.ts
@@ -15,6 +15,7 @@ const client = new Discord.Client({
 });
 
 client.on('ready', async () => {
+    console.log(`entered ready (${client.uptime})`);
     await ClientReadyEvent.React(client);
 });
 client.on('guildCreate', async (guild) => {
@@ -27,6 +28,7 @@ client.on('message', async (message) => {
     await MessageEvent.React(message, client.user.username, client.user.avatarURL);
 });
 client.on('error', async (error) => {
+    console.log(`entered error (${client.uptime})`);
     await GlobalErrorEvent.React(error);
 });
 client.login(process.env['apiKey']);

--- a/sources/businesslogic/services/guild.configuration.service.ts
+++ b/sources/businesslogic/services/guild.configuration.service.ts
@@ -12,6 +12,8 @@ export abstract class GuildConfigurationService {
     public static async Initialize(
         client: Client
     ): Promise<void> {
+        this.guildsSettings = [];
+
         let persistedParams = await Dal.Manipulation.GuildsStore.getAll();
 
         client.guilds.forEach(async (guild) => {

--- a/sources/front/events/discord.client.ready.event.ts
+++ b/sources/front/events/discord.client.ready.event.ts
@@ -15,6 +15,7 @@ export abstract class ClientReadyEvent {
 
             await GuildConfigurationService.Initialize(client);
 
+            CyclicActivityNotice.Stop();
             await CyclicActivityNotice.Start(client);
 
             // let link = generateInviteLink(client);

--- a/sources/front/tasks/cyclic.activity.notice.task.ts
+++ b/sources/front/tasks/cyclic.activity.notice.task.ts
@@ -1,4 +1,4 @@
-﻿import { Client, TextChannel } from 'discord.js';
+﻿import { Client, TextChannel, GuildChannel } from 'discord.js';
 import * as Schedule from 'node-schedule';
 import * as Dal from 'kubot-dal';
 
@@ -44,13 +44,16 @@ export abstract class CyclicActivityNotice {
                         let cachedActivity = activityCache.find(cache => cache.guildId === guildConfiguration.guildId);
                         let similar = await this.CompareActivity(cachedActivity, currentActivity);
 
-                        
+
                         if (currentActivity.length > 0 && !similar) {
                             let guild = client.guilds.find(guild => guild.id === guildConfiguration.guildId);
                             if (guild !== undefined) {
-                                let emergencyChannel = guild.channels.find(channel => channel.name === guildConfiguration.emergencyChannelName && channel.type === 'text');
-                                if (emergencyChannel !== undefined) {
-                                    messageId = await this.ReportActivity(cachedActivity, <TextChannel>emergencyChannel, currentActivity);
+                                let emergencyChannel: GuildChannel = guild.channels.find(channel => channel.name === guildConfiguration.emergencyChannelName && channel.type === 'text');
+                                if (emergencyChannel !== undefined && emergencyChannel instanceof TextChannel) {
+                                    messageId = await this.ReportActivity(cachedActivity, emergencyChannel, currentActivity);
+                                } else {
+                                    console.log(`couldn't locate emergency for:${guildConfiguration.guildId}`);
+                                    console.log(guild.channels);
                                 }
                             }
                         }
@@ -71,7 +74,9 @@ export abstract class CyclicActivityNotice {
     }
 
     public static Stop(): void {
-        this.job.cancel();
+        if (this.job instanceof Schedule.Job) {
+            this.job.cancel();
+        }
     }
 
     private static async AsyncForEach(

--- a/sources/front/tasks/cyclic.activity.notice.task.ts
+++ b/sources/front/tasks/cyclic.activity.notice.task.ts
@@ -24,8 +24,6 @@ export abstract class CyclicActivityNotice {
             rule.minute = new Schedule.Range(0, 59, 30);
 
             this.job = Schedule.scheduleJob(rule, async () => {
-                console.log(`started new task (${client.uptime})`);
-
                 this.onlinePlayers = await OnlinePlayersService.GetList();
                 this.watchedFactions = await Dal.Manipulation.FactionWatchStore.getAll();
                 this.watchedRegions = await Dal.Manipulation.RegionWatchStore.getAll();
@@ -76,7 +74,6 @@ export abstract class CyclicActivityNotice {
 
     public static Stop(): void {
         if (this.job instanceof Schedule.Job) {
-            console.log('stopping task');
             this.job.cancel();
         }
     }

--- a/sources/front/tasks/cyclic.activity.notice.task.ts
+++ b/sources/front/tasks/cyclic.activity.notice.task.ts
@@ -24,6 +24,7 @@ export abstract class CyclicActivityNotice {
             rule.minute = new Schedule.Range(0, 59, 30);
 
             this.job = Schedule.scheduleJob(rule, async () => {
+                console.log(`started new task (${client.uptime})`);
 
                 this.onlinePlayers = await OnlinePlayersService.GetList();
                 this.watchedFactions = await Dal.Manipulation.FactionWatchStore.getAll();
@@ -75,6 +76,7 @@ export abstract class CyclicActivityNotice {
 
     public static Stop(): void {
         if (this.job instanceof Schedule.Job) {
+            console.log('stopping task');
             this.job.cancel();
         }
     }


### PR DESCRIPTION
The bot was sending multiple times the same message for each guild (activity notice).

Turns out it was the GuildConfigurationService.Initialize which wasn't emptying the guildsSettings array before pushing into it, leading to duplicates.
Should be fixed at last.